### PR TITLE
hw9-saga submission

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,8 +2,6 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi v1.5.5
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+Licev
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
 github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -67,7 +67,7 @@ func (m *Repository) Subscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = m.DB.AddSubscription(email)
+	err = m.Services.Subscriber.AddSubscription(email)
 	if err != nil {
 		_ = jsonutils.ErrorJSON(w, err, http.StatusInternalServerError)
 		return
@@ -89,7 +89,7 @@ func (m *Repository) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = m.DB.DeleteSubscription(email)
+	err = m.Services.Subscriber.DeleteSubscription(email)
 	if err != nil {
 		_ = jsonutils.ErrorJSON(w, err, http.StatusInternalServerError)
 		return

--- a/internal/handlers/repository.go
+++ b/internal/handlers/repository.go
@@ -10,19 +10,19 @@ import (
 type (
 	// Services is the repository type.
 	Services struct {
-		Fetcher  rateapi.Fetcher
-		Notifier *notifier.Notifier
+		Fetcher    rateapi.Fetcher
+		Notifier   *notifier.Notifier
+		Subscriber subscriber
 	}
 
 	// Repository is the repository type
 	Repository struct {
 		App      *config.AppConfig
-		DB       dbConnection
 		Services *Services
 	}
 
-	// dbConnection defines an interface for the database connection.
-	dbConnection interface {
+	// subscriber defines an interface for managing subscriptions.
+	subscriber interface {
 		AddSubscription(emailAddr string) error
 		DeleteSubscription(emailAddr string) error
 		GetSubscriptions(limit, offset int) ([]models.Subscription, error)
@@ -33,10 +33,9 @@ type (
 var Repo *Repository
 
 // NewRepo creates a new Repository
-func NewRepo(a *config.AppConfig, services *Services, conn dbConnection) *Repository {
+func NewRepo(a *config.AppConfig, services *Services) *Repository {
 	return &Repository{
 		App:      a,
-		DB:       conn,
 		Services: services,
 	}
 }

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -12,8 +12,8 @@ import (
 
 const batchSize = 100
 
-// dbConnection defines an interface for the database connection.
-type dbConnection interface {
+// subscriber defines an interface for managing subscribers.
+type subscriber interface {
 	GetSubscriptions(limit, offset int) ([]models.Subscription, error)
 }
 
@@ -28,17 +28,17 @@ type outbox interface {
 }
 
 type Notifier struct {
-	DB      dbConnection
-	Fetcher fetcher
-	Outbox  outbox
+	Subscriber subscriber
+	Fetcher    fetcher
+	Outbox     outbox
 }
 
 // NewNotifier creates a new Notifier.
-func NewNotifier(db dbConnection, f fetcher, o outbox) *Notifier {
+func NewNotifier(s subscriber, f fetcher, o outbox) *Notifier {
 	return &Notifier{
-		DB:      db,
-		Fetcher: f,
-		Outbox:  o,
+		Subscriber: s,
+		Fetcher:    f,
+		Outbox:     o,
 	}
 }
 
@@ -57,7 +57,7 @@ func (n *Notifier) Start() error {
 	var offset int
 	errChan := make(chan error, 1)
 	for {
-		subscriptions, err := n.DB.GetSubscriptions(batchSize, offset)
+		subscriptions, err := n.Subscriber.GetSubscriptions(batchSize, offset)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/gormstorage/consumed_event.go
+++ b/internal/storage/gormstorage/consumed_event.go
@@ -1,4 +1,4 @@
-package gormrepo
+package gormstorage
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 
 // AddConsumedEvent creates a new consumer.ConsumedEvent record.
 func (c *Connection) AddConsumedEvent(event consumer.ConsumedEvent) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	result := c.db.WithContext(ctx).Create(event)

--- a/internal/storage/gormstorage/driver.go
+++ b/internal/storage/gormstorage/driver.go
@@ -1,4 +1,4 @@
-package gormrepo
+package gormstorage
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const timeout = time.Second * 5
+const RequestTimeout = time.Second * 5
 
 type Connection struct {
 	db *gorm.DB
@@ -65,7 +65,7 @@ func (c *Connection) Close() error {
 
 // Migrate performs a database migration for given models.
 func (c *Connection) Migrate(models ...any) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	err := c.db.WithContext(ctx).AutoMigrate(models...)
@@ -78,7 +78,7 @@ func (c *Connection) Migrate(models ...any) error {
 
 // BeginTransaction begins a transaction.
 func (c *Connection) BeginTransaction() (*gorm.DB, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	tx := c.db.WithContext(ctx).Begin()

--- a/internal/storage/gormstorage/event.go
+++ b/internal/storage/gormstorage/event.go
@@ -1,4 +1,4 @@
-package gormrepo
+package gormstorage
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 
 // AddEvent creates a new outbox.Event record.
 func (c *Connection) AddEvent(event *outbox.Event) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	result := c.db.WithContext(ctx).Create(event)
@@ -21,7 +21,7 @@ func (c *Connection) AddEvent(event *outbox.Event) error {
 // FetchUnpublishedEvents retrieves all events from the database that have not been
 // published after the specified offset.
 func (c *Connection) FetchUnpublishedEvents(lastOffset uint) ([]outbox.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	var events []outbox.Event

--- a/internal/storage/gormstorage/offset.go
+++ b/internal/storage/gormstorage/offset.go
@@ -1,4 +1,4 @@
-package gormrepo
+package gormstorage
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 
 // GetLastOffset retrieves the last offset for a given topic from the database.
 func (c *Connection) GetLastOffset(topic string, partition int) (producer.Offset, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	var lastOffset producer.Offset
@@ -22,7 +22,7 @@ func (c *Connection) GetLastOffset(topic string, partition int) (producer.Offset
 // UpdateOffset updates the offset in the database to reflect the latest published
 // event's ID.
 func (c *Connection) UpdateOffset(offset *producer.Offset) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
 	defer cancel()
 
 	return c.db.WithContext(ctx).Save(offset).Error

--- a/internal/subscriber/gormsubscriber/actions.go
+++ b/internal/subscriber/gormsubscriber/actions.go
@@ -1,0 +1,59 @@
+package gormsubscriber
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/email"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/models"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/storage/gormstorage"
+)
+
+var ErrorInvalidEmail = errors.New("invalid email")
+
+// validateSubscription is an action that validates a subscription by validating an
+// email address and checking if it already exists.
+func validateSubscription(saga *State, s *Subscriber) error {
+	// Validate the email format
+	if !email.Email(saga.Email).Validate() {
+		return ErrorInvalidEmail
+	}
+
+	// Check if the subscription already exists
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
+	defer cancel()
+
+	var count int64
+	err := s.db.WithContext(ctx).Model(&models.Subscription{}).Where("email = ?", saga.Email).Count(&count).Error
+	if err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return ErrorDuplicateSubscription
+	}
+
+	return nil
+}
+
+// addSubscription is an action that creates a new models.Subscription record.
+func addSubscription(saga *State, s *Subscriber) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
+	defer cancel()
+
+	subscription := models.Subscription{
+		Email:     saga.Email,
+		CreatedAt: time.Now(),
+	}
+	result := s.db.WithContext(ctx).Create(&subscription)
+	if result.Error != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" {
+			return ErrorDuplicateSubscription
+		}
+		return result.Error
+	}
+	return nil
+}

--- a/internal/subscriber/gormsubscriber/compensations.go
+++ b/internal/subscriber/gormsubscriber/compensations.go
@@ -1,0 +1,21 @@
+package gormsubscriber
+
+import (
+	"context"
+
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/models"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/storage/gormstorage"
+)
+
+// deleteSubscription is a compensation to addSubscription that deletes a
+// models.Subscription record, queried by an email address.
+func deleteSubscription(saga *State, s *Subscriber) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
+	defer cancel()
+
+	result := s.db.WithContext(ctx).Where("email = ?", saga.Email).Delete(&models.Subscription{})
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/internal/subscriber/gormsubscriber/saga.go
+++ b/internal/subscriber/gormsubscriber/saga.go
@@ -1,0 +1,127 @@
+package gormsubscriber
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/storage/gormstorage"
+	"gorm.io/gorm"
+)
+
+const (
+	StatusCompleted  = "completed"
+	StatusInProgress = "in_progress"
+	StatusFailed     = "failed"
+)
+
+// State represents the current state of the SAGA transaction.
+type State struct {
+	ID             string `gorm:"primary_key"`
+	CurrentStep    int
+	Email          string
+	IsCompensating bool
+	Status         string // StatusCompleted, StatusInProgress, StatusFailed
+}
+
+// Step represents a single step in the SAGA transaction.
+type Step struct {
+	Action       func(saga *State, s *Subscriber) error
+	Compensation func(saga *State, s *Subscriber) error
+}
+
+// Orchestrator manages the execution of SAGA steps.
+type Orchestrator struct {
+	Steps []Step
+	State State
+	db    *gorm.DB
+}
+
+// NewSagaOrchestrator creates a new SAGA Orchestrator.
+func NewSagaOrchestrator(email string, db *gorm.DB) (*Orchestrator, error) {
+	err := db.AutoMigrate(&State{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to migrate events")
+	}
+
+	return &Orchestrator{
+		Steps: []Step{
+			{
+				Action:       validateSubscription,
+				Compensation: nil,
+			},
+			{
+				Action:       addSubscription,
+				Compensation: deleteSubscription,
+			},
+		},
+		State: State{
+			ID:             uuid.New().String(),
+			CurrentStep:    0,
+			Email:          email,
+			IsCompensating: false,
+			Status:         StatusInProgress,
+		},
+		db: db,
+	}, nil
+}
+
+// Run runs the SAGA Orchestrator.
+func (o *Orchestrator) Run(s *Subscriber) error {
+	for o.State.CurrentStep < len(o.Steps) {
+		step := o.Steps[o.State.CurrentStep]
+		var err error
+
+		if o.State.IsCompensating {
+			if step.Compensation != nil {
+				err = step.Compensation(&o.State, s)
+			}
+		} else {
+			err = step.Action(&o.State, s)
+		}
+
+		if err != nil {
+			o.State.IsCompensating = true
+			err = o.saveState()
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		if o.State.IsCompensating {
+			o.State.CurrentStep--
+			if o.State.CurrentStep < 0 {
+				o.State.Status = StatusFailed
+				err = o.saveState()
+				if err != nil {
+					return err
+				}
+				return err
+			}
+		} else {
+			o.State.CurrentStep++
+		}
+		err = o.saveState()
+		if err != nil {
+			return err
+		}
+	}
+
+	if !o.State.IsCompensating {
+		o.State.Status = StatusCompleted
+		err := o.saveState()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// saveState saves the SAGA transaction to the database.
+func (o *Orchestrator) saveState() error {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
+	defer cancel()
+
+	return o.db.WithContext(ctx).Save(&o.State).Error
+}

--- a/internal/subscriber/gormsubscriber/subscriber.go
+++ b/internal/subscriber/gormsubscriber/subscriber.go
@@ -1,13 +1,14 @@
-package gormrepo
+package gormsubscriber
 
 import (
 	"context"
 	"errors"
 	"time"
 
-	"github.com/vladyslavpavlenko/genesis-api-project/internal/models"
-
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/models"
+	"github.com/vladyslavpavlenko/genesis-api-project/internal/storage/gormstorage"
+	"gorm.io/gorm"
 )
 
 var (
@@ -15,16 +16,27 @@ var (
 	ErrorNonExistentSubscription = errors.New("subscription does not exist")
 )
 
+type Subscriber struct {
+	db *gorm.DB
+}
+
+// NewSubscriber creates a new Subscriber.
+func NewSubscriber(db *gorm.DB) *Subscriber {
+	return &Subscriber{
+		db: db,
+	}
+}
+
 // AddSubscription creates a new models.Subscription record.
-func (c *Connection) AddSubscription(email string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func (s *Subscriber) AddSubscription(email string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
 	defer cancel()
 
 	subscription := models.Subscription{
 		Email:     email,
 		CreatedAt: time.Now(),
 	}
-	result := c.db.WithContext(ctx).Create(&subscription)
+	result := s.db.WithContext(ctx).Create(&subscription)
 	if result.Error != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" {
@@ -36,11 +48,11 @@ func (c *Connection) AddSubscription(email string) error {
 }
 
 // DeleteSubscription deletes a models.Subscription record.
-func (c *Connection) DeleteSubscription(email string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func (s *Subscriber) DeleteSubscription(email string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
 	defer cancel()
 
-	result := c.db.WithContext(ctx).Where("email = ?", email).Delete(&models.Subscription{})
+	result := s.db.WithContext(ctx).Where("email = ?", email).Delete(&models.Subscription{})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -55,12 +67,12 @@ func (c *Connection) DeleteSubscription(email string) error {
 // GetSubscriptions returns a paginated list of subscriptions. Limit specifies the number of records to be retrieved
 // Limit conditions can be canceled by using `Limit(-1)`. Offset specify the number of records to skip before starting
 // to return the records. Offset conditions can be canceled by using `Offset(-1)`.
-func (c *Connection) GetSubscriptions(limit, offset int) ([]models.Subscription, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func (s *Subscriber) GetSubscriptions(limit, offset int) ([]models.Subscription, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gormstorage.RequestTimeout)
 	defer cancel()
 
 	var subscriptions []models.Subscription
-	result := c.db.WithContext(ctx).Limit(limit).Offset(offset).Find(&subscriptions)
+	result := s.db.WithContext(ctx).Limit(limit).Offset(offset).Find(&subscriptions)
 	if result.Error != nil {
 		return nil, result.Error
 	}


### PR DESCRIPTION
- make `Subscriber` a separate service;
- update tests for the `handlers` package;
- add SAGA orchestration functionality to the `Subscriber` service;
- add SAGA flow for the subscription creation process;
- update golanci-lint GitHub triggers.